### PR TITLE
surface `forge fmt` errors, clean up and colorize terminal output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "scopelint"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "colored",
  "grep",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,6 +434,7 @@ dependencies = [
 name = "scopelint"
 version = "0.0.10"
 dependencies = [
+ "colored",
  "grep",
  "regex",
  "taplo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@
   version = "0.0.10"
 
 [dependencies]
+colored = "2.0.0"
   grep = "0.2.10"
   regex = "1.6.0"
   taplo = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
   license = "MIT"
   name = "scopelint"
   repository = "https://github.com/ScopeLift/scopelint"
-  version = "0.0.10"
+  version = "0.0.11"
 
 [dependencies]
 colored = "2.0.0"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Formatting and checking does the following:
 - Install with `cargo install scopelint`.
 - Format code with `scopelint fmt`.
 - Validate formatting with `scopelint check`.
+- Print the version with `scopelint --version`.
 - Use the ScopeLift [foundry template](https://github.com/ScopeLift/foundry-template/) to automatically run scopelint and slither in CI.
 
 ## Limitations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ impl Config {
                 "fmt" => Ok(Self { mode: Mode::Format }),
                 "check" => Ok(Self { mode: Mode::Check }),
                 "--version" | "-v" => Ok(Self { mode: Mode::Version }),
-                _ => Err("Unrecognized mode"),
+                _ => Err("Unrecognized mode: Must be 'fmt', 'check', or '--version'"),
             },
             _ => Err("Too many arguments"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ impl Config {
             2 => match args[1].as_str() {
                 "fmt" => Ok(Self { mode: Mode::Format }),
                 "check" => Ok(Self { mode: Mode::Check }),
-                "version" => Ok(Self { mode: Mode::Version }),
+                "--version" | "-v" => Ok(Self { mode: Mode::Version }),
                 _ => Err("Unrecognized mode"),
             },
             _ => Err("Too many arguments"),
@@ -84,9 +84,8 @@ fn fmt(taplo_opts: taplo::formatter::Options) -> Result<(), Box<dyn Error>> {
     let forge_status = process::Command::new("forge").arg("fmt").output()?;
 
     // Print any warnings/errors from `forge fmt`.
-    let stderr = String::from_utf8(forge_status.stderr)?;
-    if !stderr.is_empty() {
-        print!("{stderr}");
+    if !forge_status.stderr.is_empty() {
+        print!("{}", String::from_utf8(forge_status.stderr)?);
     }
 
     // Format `foundry.toml` with taplo.
@@ -120,7 +119,7 @@ fn validate_fmt(taplo_opts: taplo::formatter::Options) -> Result<(), Box<dyn Err
     // Print any warnings/errors from `forge fmt`.
     let stderr = String::from_utf8(forge_status.stderr)?;
     let forge_ok = forge_status.status.success() && stderr.is_empty();
-    print!("{stderr}");
+    print!("{stderr}"); // Prints nothing if stderr is empty.
 
     // Check TOML with `taplo fmt`
     let config_orig = fs::read_to_string("./foundry.toml")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,19 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs, unreachable_pub, unused, rust_2021_compatibility)]
 #![warn(clippy::all, clippy::pedantic, clippy::cargo, clippy::nursery)]
+use colored::Colorize;
 use std::{env, process};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
 
     let config = scopelint::Config::build(&args).unwrap_or_else(|err| {
-        eprintln!("Problem parsing arguments: {err}");
+        eprintln!("{}: Argument parsing failed with '{err}'", "error".bold().red());
         process::exit(1);
     });
 
-    if let Err(err) = scopelint::run(&config) {
-        eprintln!("\nExecution failed: {err}");
+    if let Err(_err) = scopelint::run(&config) {
+        // All warnings/errors have already been logged.
         process::exit(1);
     }
 }


### PR DESCRIPTION
Sample output now looks like this

<img width="593" alt="image" src="https://user-images.githubusercontent.com/17163988/200045173-669eca09-7ba7-4b72-81c7-005d8ada7529.png">
