### PR TITLE
fix: don't check non-solidity files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs, unreachable_pub, unused, rust_2021_compatibility)]
 #![warn(clippy::all, clippy::pedantic, clippy::cargo, clippy::nursery)]
-#![feature(option_result_contains)]
 
 use colored::Colorize;
 use grep::{
@@ -261,7 +260,9 @@ fn validate(paths: [&str; 3]) -> Result<ValidationResults, Box<dyn Error>> {
             if !dent.file_type().is_file() {
                 continue
             }
-            if !dent.path().to_str().contains(&".sol") {
+            if !dent.file_type().is_file() ||
+                !dent.path().to_str().expect("Expected string for a filename").ends_with(&".sol")
+            {
                 continue
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs, unreachable_pub, unused, rust_2021_compatibility)]
 #![warn(clippy::all, clippy::pedantic, clippy::cargo, clippy::nursery)]
+#![feature(option_result_contains)]
 
 use colored::Colorize;
 use grep::{
@@ -258,6 +259,9 @@ fn validate(paths: [&str; 3]) -> Result<ValidationResults, Box<dyn Error>> {
             };
 
             if !dent.file_type().is_file() {
+                continue
+            }
+            if !dent.path().to_str().contains(&".sol") {
                 continue
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use grep::{
     searcher::{sinks::UTF8, BinaryDetection, SearcherBuilder},
 };
 use regex::Regex;
-use std::{error::Error, fmt, fs, process};
+use std::{error::Error, ffi::OsStr, fmt, fs, process};
 use walkdir::WalkDir;
 
 // ========================
@@ -257,12 +257,7 @@ fn validate(paths: [&str; 3]) -> Result<ValidationResults, Box<dyn Error>> {
                 }
             };
 
-            if !dent.file_type().is_file() {
-                continue
-            }
-            if !dent.file_type().is_file() ||
-                !dent.path().to_str().expect("Expected string for a filename").ends_with(&".sol")
-            {
+            if !dent.file_type().is_file() || dent.path().extension() != Some(OsStr::new("sol")) {
                 continue
             }
 


### PR DESCRIPTION
If a file name doesn't contain ".sol", it won't be checked