### PR TITLE
refactor: solang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "parking_lot"
@@ -603,6 +603,7 @@ name = "scopelint"
 version = "0.0.11"
 dependencies = [
  "colored",
+ "once_cell",
  "regex",
  "solang-parser",
  "taplo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,16 +56,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base64"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
-
-[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
@@ -64,16 +88,8 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
- "lazy_static",
  "memchr",
- "regex-automata",
 ]
-
-[[package]]
-name = "bytecount"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "cfg-if"
@@ -99,28 +115,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.31"
+name = "ena"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
 dependencies = [
- "cfg-if",
+ "log",
 ]
 
 [[package]]
-name = "encoding_rs_io"
-version = "0.1.7"
+name = "fixedbitset"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
-dependencies = [
- "encoding_rs",
-]
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -153,90 +199,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "grep"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cea81f81c4c120466aef365c225a05c707b002a20f2b9fe3287124b809a8d4f"
-dependencies = [
- "grep-cli",
- "grep-matcher",
- "grep-printer",
- "grep-regex",
- "grep-searcher",
-]
-
-[[package]]
-name = "grep-cli"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd110c34bb4460d0de5062413b773e385cbf8a85a63fc535590110a09e79e8a"
-dependencies = [
- "atty",
- "bstr",
- "globset",
- "lazy_static",
- "log",
- "regex",
- "same-file",
- "termcolor",
- "winapi-util",
-]
-
-[[package]]
-name = "grep-matcher"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d27563c33062cd33003b166ade2bb4fd82db1fd6a86db764dfdad132d46c1cc"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "grep-printer"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c271a24daedf5675b61a275a1d0af06e03312ab7856d15433ae6cde044dc72"
-dependencies = [
- "base64",
- "bstr",
- "grep-matcher",
- "grep-searcher",
- "serde",
- "serde_json",
- "termcolor",
-]
-
-[[package]]
-name = "grep-regex"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1345f8d33c89f2d5b081f2f2a41175adef9fd0bed2fea6a26c96c2deb027e58e"
-dependencies = [
- "aho-corasick",
- "bstr",
- "grep-matcher",
- "log",
- "regex",
- "regex-syntax",
- "thread_local",
-]
-
-[[package]]
-name = "grep-searcher"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48852bd08f9b4eb3040ecb6d2f4ade224afe880a9a0909c5563cc59fa67932cc"
-dependencies = [
- "bstr",
- "bytecount",
- "encoding_rs",
- "encoding_rs_io",
- "grep-matcher",
- "log",
- "memmap2",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +211,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -267,6 +239,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
+name = "lalrpop"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30455341b0e18f276fa64540aff54deafb54c589de6aca68659c63dd2d5d823"
+dependencies = [
+ "ascii-canvas",
+ "atty",
+ "bit-set",
+ "diff",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf796c978e9b4d983414f4caedc9273aa33ee214c5b887bd55fde84c85d2dc4"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +281,16 @@ name = "libc"
 version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -317,15 +331,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "memmap2"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +338,12 @@ checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "num_threads"
@@ -350,10 +361,111 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -374,6 +486,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,12 +545,6 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
@@ -416,6 +572,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,12 +593,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "scopelint"
 version = "0.0.11"
 dependencies = [
  "colored",
- "grep",
  "regex",
+ "solang-parser",
  "taplo",
  "walkdir",
 ]
@@ -473,6 +641,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
+name = "smallvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "solang-parser"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8ac4bfef383f368bd9bb045107a501cd9cd0b64ad1983e1b7e839d6a44ecad"
+dependencies = [
+ "itertools",
+ "lalrpop",
+ "lalrpop-util",
+ "phf",
+ "unicode-xid",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,12 +711,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
+name = "term"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
- "winapi-util",
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -540,15 +748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "time"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +764,15 @@ name = "time-macros"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
 
 [[package]]
 name = "tracing"
@@ -603,6 +811,12 @@ name = "unicode-ident"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "version_check"
@@ -657,3 +871,60 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@
 
 [dependencies]
   colored = "2.0.0"
+  once_cell = "1.16.0"
   regex = "1.6.0"
-solang-parser = "0.1.18"
+  solang-parser = "0.1.18"
   taplo = "0.11.0"
   walkdir = "2.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@
   version = "0.0.11"
 
 [dependencies]
-colored = "2.0.0"
-  grep = "0.2.10"
+  colored = "2.0.0"
   regex = "1.6.0"
+solang-parser = "0.1.18"
   taplo = "0.11.0"
   walkdir = "2.3.2"

--- a/README.md
+++ b/README.md
@@ -25,5 +25,4 @@ Formatting and checking does the following:
 
 ## Limitations
 
-1. This tool is currently opinionated and does not let you configure it's behavior.
-2. It's regex-based, so it may not be perfect&mdash;for example, it doesn't care that code is commented out.
+This tool is currently opinionated and does not let you configure it's behavior.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,10 @@
 #![warn(clippy::all, clippy::pedantic, clippy::cargo, clippy::nursery)]
 
 use colored::Colorize;
-use grep::{
-    matcher::Matcher,
-    regex::RegexMatcher,
-    searcher::{sinks::UTF8, BinaryDetection, SearcherBuilder},
-};
 use regex::Regex;
+use solang_parser::pt::{
+    ContractPart, FunctionAttribute, SourceUnitPart, VariableAttribute, Visibility,
+};
 use std::{error::Error, ffi::OsStr, fmt, fs, process};
 use walkdir::WalkDir;
 
@@ -158,7 +156,6 @@ enum Validator {
 struct InvalidItem {
     kind: Validator,
     file: String, // File name.
-    line: u64,    // Line number.
     text: String, // Incorrectly named item.
 }
 
@@ -166,20 +163,14 @@ impl InvalidItem {
     fn description(&self) -> String {
         match self.kind {
             Validator::Test => {
-                format!("Invalid test name in {} on line {}: {}", self.file, self.line, self.text)
+                format!("Invalid test name in {}: {}", self.file, self.text)
             }
             Validator::Constant => {
-                format!(
-                    "Invalid constant or immutable name in {} on line {}: {}",
-                    self.file, self.line, self.text
-                )
+                format!("Invalid constant or immutable name in {}: {}", self.file, self.text)
             }
             Validator::Script => format!("Invalid script interface in {}", self.file),
             Validator::Src => {
-                format!(
-                    "Invalid src method name in {} on line {}: {}",
-                    self.file, self.line, self.text
-                )
+                format!("Invalid src method name in {}: {}", self.file, self.text)
             }
         }
     }
@@ -228,26 +219,13 @@ impl ValidationResults {
 }
 
 fn validate(paths: [&str; 3]) -> Result<ValidationResults, Box<dyn Error>> {
-    // Test and constant matchers are a single line, so we use `new_line_matcher`, but function
-    // signatures may be multi-line, so we use `new`.
-    let test_matcher = RegexMatcher::new_line_matcher(r"function\s*test\w+\(")?;
-    let constant_matcher = RegexMatcher::new_line_matcher(r"\sconstant\s")?;
-    let fn_matcher = RegexMatcher::new(r"function\s+\w+\([\w\s,]*\)[\w\s]*\{")?;
-
-    let mut searcher = SearcherBuilder::new()
-        .binary_detection(BinaryDetection::quit(b'\x00'))
-        .line_number(true)
-        .build();
-
-    let mut multiline_searcher = SearcherBuilder::new()
-        .binary_detection(BinaryDetection::quit(b'\x00'))
-        .line_number(true)
-        .multi_line(true)
-        .build();
-
     let mut results = ValidationResults::new();
 
     for path in paths {
+        let is_test = path == "./test";
+        let is_src = path == "./src";
+        let is_script = path == "./script";
+
         for result in WalkDir::new(path) {
             let dent = match result {
                 Ok(dent) => dent,
@@ -261,171 +239,122 @@ fn validate(paths: [&str; 3]) -> Result<ValidationResults, Box<dyn Error>> {
                 continue
             }
 
-            // Validate test naming convention.
-            searcher.search_path(
-                &test_matcher,
-                dent.path(),
-                UTF8(|lnum, line| {
-                    if let Some(i) = check_test(&test_matcher, &dent, lnum, line) {
-                        results.invalid_tests.push(i);
-                    }
-                    Ok(true)
-                }),
-            )?;
+            // Get the parse tree (pt) of the file.
+            let content = fs::read_to_string(dent.path())?;
+            let (pt, _comments) = solang_parser::parse(&content, 0).expect("Parsing failed");
 
-            // Validate constant/immutable naming convention.
-            searcher.search_path(
-                &constant_matcher,
-                dent.path(),
-                UTF8(|lnum, line| {
-                    if let Some(item) = check_constant(&dent, lnum, line) {
-                        results.invalid_constants.push(item);
-                    }
-                    Ok(true)
-                }),
-            )?;
+            // Variables used to track status of checks that are file-wide.
+            let mut num_public_script_methods = 0;
 
-            // Validate src contract function names have leading underscores if internal/private.
-            if path == "./src" {
-                multiline_searcher.search_path(
-                    &fn_matcher,
-                    dent.path(),
-                    UTF8(|lnum, line| {
-                        if let Some(item) = check_src_fn(&fn_matcher, &dent, lnum, line) {
-                            results.invalid_src.push(item);
+            // Run checks.
+            for element in pt.0 {
+                match element {
+                    SourceUnitPart::ContractDefinition(c) => {
+                        for el in c.parts {
+                            match el {
+                                ContractPart::VariableDefinition(v) => {
+                                    let name = v.name.name;
+                                    let is_constant = v.attrs.iter().any(|a| {
+                                        matches!(
+                                            a,
+                                            VariableAttribute::Constant(_) |
+                                                VariableAttribute::Immutable(_)
+                                        )
+                                    });
+                                    if is_constant && !is_valid_constant_name(&name) {
+                                        results.invalid_constants.push(InvalidItem {
+                                            kind: Validator::Constant,
+                                            file: dent.path().display().to_string(),
+                                            text: name,
+                                        });
+                                    }
+                                }
+                                ContractPart::FunctionDefinition(f) => {
+                                    // Validate test function naming convention.
+                                    let name = f.name.unwrap().name;
+                                    if is_test && !is_valid_test_name(&name) {
+                                        results.invalid_tests.push(InvalidItem {
+                                            kind: Validator::Test,
+                                            file: dent.path().display().to_string(),
+                                            text: name.clone(),
+                                        });
+                                    }
+
+                                    let is_private = f.attributes.iter().any(|a| match a {
+                                        FunctionAttribute::Visibility(v) => {
+                                            matches!(
+                                                v,
+                                                Visibility::Private(_) | Visibility::Internal(_)
+                                            )
+                                        }
+                                        _ => false,
+                                    });
+
+                                    if is_script && !is_private && name != "setUp" {
+                                        num_public_script_methods += 1;
+                                    }
+
+                                    if is_src && is_private && !is_valid_src_name(&name) {
+                                        results.invalid_src.push(InvalidItem {
+                                            kind: Validator::Src,
+                                            file: dent.path().display().to_string(),
+                                            text: name,
+                                        });
+                                    }
+                                }
+                                ContractPart::StructDefinition(_) |
+                                ContractPart::EventDefinition(_) |
+                                ContractPart::EnumDefinition(_) |
+                                ContractPart::ErrorDefinition(_) |
+                                ContractPart::TypeDefinition(_) |
+                                ContractPart::StraySemicolon(_) |
+                                ContractPart::Using(_) => (),
+                            }
                         }
-                        Ok(true)
-                    }),
-                )?;
+                    }
+                    SourceUnitPart::PragmaDirective(_, _, _) |
+                    SourceUnitPart::ImportDirective(_) |
+                    SourceUnitPart::EnumDefinition(_) |
+                    SourceUnitPart::StructDefinition(_) |
+                    SourceUnitPart::EventDefinition(_) |
+                    SourceUnitPart::ErrorDefinition(_) |
+                    SourceUnitPart::FunctionDefinition(_) |
+                    SourceUnitPart::VariableDefinition(_) |
+                    SourceUnitPart::TypeDefinition(_) |
+                    SourceUnitPart::Using(_) |
+                    SourceUnitPart::StraySemicolon(_) => (),
+                }
             }
 
             // Validate scripts only have a single run method.
-            if path == "./script" {
-                if let Some(i) = check_script(&dent)? {
-                    results.invalid_scripts.push(i);
-                }
+            // TODO Script checks don't really fit nicely into InvalidItem, refactor needed to log
+            // more details about the invalid script's ABI.
+            if num_public_script_methods > 1 {
+                results.invalid_scripts.push(InvalidItem {
+                    kind: Validator::Script,
+                    file: dent.path().display().to_string(),
+                    text: String::new(),
+                });
             }
         }
     }
     Ok(results)
 }
 
-fn check_test(
-    matcher: &RegexMatcher,
-    dent: &walkdir::DirEntry,
-    lnum: u64,
-    line: &str,
-) -> Option<InvalidItem> {
-    // We are guaranteed to find a match, so the unwrap is ok.
-    let the_match = matcher.find(line.as_bytes()).unwrap().unwrap();
-    let text = line[the_match].to_string();
-
-    // Check if it matches our pattern.
-    let pattern = r"test(Fork)?(Fuzz)?_(Revert(If_|When_){1})?\w+\(";
-    let validator = RegexMatcher::new_line_matcher(pattern).unwrap();
-
-    // If match is found, test name is good, otherwise it's bad.
-    let match_result = validator.find(text.as_bytes()).unwrap();
-    if match_result.is_some() {
-        return None
+fn is_valid_test_name(name: &str) -> bool {
+    if !name.starts_with("test") {
+        return true // Not a test function, so return.
     }
-
-    let trimmed_test = text.trim();
-    let item = InvalidItem {
-        kind: Validator::Test,
-        file: dent.path().to_str().unwrap().to_string(),
-        line: lnum,
-        // Trim off the leading "function " and remove the trailing "(".
-        text: trimmed_test[9..trimmed_test.len() - 1].to_string(),
-    };
-
-    Some(item)
+    let regex = Regex::new(r"test(Fork)?(Fuzz)?_(Revert(If_|When_){1})?\w+").unwrap();
+    regex.is_match(name)
 }
 
-fn check_src_fn(
-    matcher: &RegexMatcher,
-    dent: &walkdir::DirEntry,
-    lnum: u64,
-    line: &str,
-) -> Option<InvalidItem> {
-    // We are guaranteed to find a match, so the unwrap is ok.
-    let the_match = matcher.find(line.as_bytes()).unwrap().unwrap();
-    let text = line[the_match].to_string();
-
-    // Ensure public/external functions have no leading underscore, and internal/private functions
-    // have a leading underscore.
-    let vis_validator = RegexMatcher::new_line_matcher(r"\b(public|external)\b").unwrap();
-    let is_public = vis_validator.find(text.as_bytes()).unwrap();
-    let name = text[9..text.len() - 1].to_string();
-    let first_char = name.trim().chars().next()?;
-
-    if is_public.is_some() && first_char != '_' || is_public.is_none() && first_char == '_' {
-        return None
-    }
-
-    let item = InvalidItem {
-        kind: Validator::Src,
-        file: dent.path().to_str().unwrap().to_string(),
-        line: lnum,
-        // Trim off the leading "function " and remove the trailing "(".
-        text: name,
-    };
-    Some(item)
+fn is_valid_src_name(name: &str) -> bool {
+    name.starts_with('_')
 }
 
-fn check_constant(dent: &walkdir::DirEntry, lnum: u64, line: &str) -> Option<InvalidItem> {
-    // Found a constant/immutable, get the var name.
-    let r = Regex::new(r"(;|=)").unwrap();
-    let mut split_str = r.split(line);
-    let var = split_str.next().expect("no match 1").split_whitespace().last().expect("no match 2");
-
+fn is_valid_constant_name(name: &str) -> bool {
     // Make sure it's ALL_CAPS: https://regex101.com/r/Pv9mD8/1
-    let name_validator = RegexMatcher::new_line_matcher(r"^_?[A-Z]+(?:_{0,1}[A-Z]+)*$").unwrap();
-
-    // If match is found, test name is good, otherwise it's bad.
-    let match_result = name_validator.find(var.as_bytes()).unwrap();
-    if match_result.is_some() {
-        return None
-    }
-
-    let item = InvalidItem {
-        kind: Validator::Constant,
-        file: dent.path().to_str().unwrap().to_string(),
-        line: lnum,
-        text: var.to_string(),
-    };
-    Some(item)
-}
-
-fn check_script(dent: &walkdir::DirEntry) -> Result<Option<InvalidItem>, Box<dyn Error>> {
-    let mut fns_found = 0;
-    let mut found_run_fn = false;
-
-    let text = fs::read_to_string(dent.path())?;
-    let fn_regex = Regex::new(r"function\s*\w*\([\w\s,]*\)[\w\s]*\{").unwrap();
-    let setup_regex = Regex::new(r"function\s*setUp\(").unwrap();
-    let public_regex = Regex::new(r"\b(public|external)\b").unwrap();
-    let run_regex = Regex::new(r"\brun\b").unwrap();
-
-    for cap in fn_regex.captures_iter(&text) {
-        let text = &cap[0];
-        if !setup_regex.is_match(text) && public_regex.is_match(text) {
-            fns_found += 1;
-            found_run_fn = found_run_fn || run_regex.is_match(text);
-        }
-    }
-
-    if fns_found == 1 && found_run_fn {
-        Ok(None)
-    } else {
-        // We only return 1 item to summarize the file.
-        // TODO Script checks don't really fit nicely into InvalidItem, refactor needed to log more
-        // details about the invalid script's ABI.
-        Ok(Some(InvalidItem {
-            kind: Validator::Script,
-            file: dent.path().to_str().unwrap().to_string(),
-            line: u64::MAX,      // We don't have the line number.
-            text: String::new(), // We don't return the text for now.
-        }))
-    }
+    let regex = Regex::new(r"^_?[A-Z]+(?:_{0,1}[A-Z]+)*$").unwrap();
+    regex.is_match(name)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,24 +177,12 @@ impl InvalidItem {
 }
 
 struct ValidationResults {
-    invalid_tests: Vec<InvalidItem>,
-    invalid_constants: Vec<InvalidItem>,
-    invalid_scripts: Vec<InvalidItem>,
-    invalid_src: Vec<InvalidItem>,
+    invalid_items: Vec<InvalidItem>,
 }
 
 impl fmt::Display for ValidationResults {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        for item in &self.invalid_tests {
-            writeln!(f, "{}", item.description())?;
-        }
-        for item in &self.invalid_constants {
-            writeln!(f, "{}", item.description())?;
-        }
-        for item in &self.invalid_scripts {
-            writeln!(f, "{}", item.description())?;
-        }
-        for item in &self.invalid_src {
+        for item in &self.invalid_items {
             writeln!(f, "{}", item.description())?;
         }
         Ok(())
@@ -203,18 +191,11 @@ impl fmt::Display for ValidationResults {
 
 impl ValidationResults {
     const fn new() -> Self {
-        Self {
-            invalid_tests: Vec::new(),
-            invalid_constants: Vec::new(),
-            invalid_scripts: Vec::new(),
-            invalid_src: Vec::new(),
-        }
+        Self { invalid_items: Vec::new() }
     }
 
     fn is_valid(&self) -> bool {
-        self.invalid_tests.is_empty() &&
-            self.invalid_constants.is_empty() &&
-            self.invalid_scripts.is_empty()
+        self.invalid_items.is_empty()
     }
 }
 
@@ -262,7 +243,7 @@ fn validate(paths: [&str; 3]) -> Result<ValidationResults, Box<dyn Error>> {
                                         )
                                     });
                                     if is_constant && !is_valid_constant_name(&name) {
-                                        results.invalid_constants.push(InvalidItem {
+                                        results.invalid_items.push(InvalidItem {
                                             kind: Validator::Constant,
                                             file: dent.path().display().to_string(),
                                             text: name,
@@ -273,7 +254,7 @@ fn validate(paths: [&str; 3]) -> Result<ValidationResults, Box<dyn Error>> {
                                     // Validate test function naming convention.
                                     let name = f.name.unwrap().name;
                                     if is_test && !is_valid_test_name(&name) {
-                                        results.invalid_tests.push(InvalidItem {
+                                        results.invalid_items.push(InvalidItem {
                                             kind: Validator::Test,
                                             file: dent.path().display().to_string(),
                                             text: name.clone(),
@@ -295,7 +276,7 @@ fn validate(paths: [&str; 3]) -> Result<ValidationResults, Box<dyn Error>> {
                                     }
 
                                     if is_src && is_private && !is_valid_src_name(&name) {
-                                        results.invalid_src.push(InvalidItem {
+                                        results.invalid_items.push(InvalidItem {
                                             kind: Validator::Src,
                                             file: dent.path().display().to_string(),
                                             text: name,
@@ -330,7 +311,7 @@ fn validate(paths: [&str; 3]) -> Result<ValidationResults, Box<dyn Error>> {
             // TODO Script checks don't really fit nicely into InvalidItem, refactor needed to log
             // more details about the invalid script's ABI.
             if num_public_script_methods > 1 {
-                results.invalid_scripts.push(InvalidItem {
+                results.invalid_items.push(InvalidItem {
                     kind: Validator::Script,
                     file: dent.path().display().to_string(),
                     text: String::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,7 @@ impl InvalidItem {
     }
 }
 
+#[derive(Default)]
 struct ValidationResults {
     invalid_items: Vec<InvalidItem>,
 }
@@ -196,10 +197,6 @@ impl fmt::Display for ValidationResults {
 }
 
 impl ValidationResults {
-    const fn new() -> Self {
-        Self { invalid_items: Vec::new() }
-    }
-
     fn is_valid(&self) -> bool {
         self.invalid_items.is_empty()
     }
@@ -267,7 +264,7 @@ impl Validate for FunctionDefinition {
 
 // Core validation method that walks the filesystem and validates all Solidity files.
 fn validate(paths: [&str; 3]) -> Result<ValidationResults, Box<dyn Error>> {
-    let mut results = ValidationResults::new();
+    let mut results = ValidationResults::default();
 
     for path in paths {
         let is_script = path == "./script";
@@ -324,25 +321,11 @@ fn validate(paths: [&str; 3]) -> Result<ValidationResults, Box<dyn Error>> {
                                         num_public_script_methods += 1;
                                     }
                                 }
-                                ContractPart::StructDefinition(_) |
-                                ContractPart::EventDefinition(_) |
-                                ContractPart::EnumDefinition(_) |
-                                ContractPart::ErrorDefinition(_) |
-                                ContractPart::TypeDefinition(_) |
-                                ContractPart::StraySemicolon(_) |
-                                ContractPart::Using(_) => (),
+                                _ => (),
                             }
                         }
                     }
-                    SourceUnitPart::PragmaDirective(_, _, _) |
-                    SourceUnitPart::ImportDirective(_) |
-                    SourceUnitPart::EnumDefinition(_) |
-                    SourceUnitPart::StructDefinition(_) |
-                    SourceUnitPart::EventDefinition(_) |
-                    SourceUnitPart::ErrorDefinition(_) |
-                    SourceUnitPart::TypeDefinition(_) |
-                    SourceUnitPart::Using(_) |
-                    SourceUnitPart::StraySemicolon(_) => (),
+                    _ => (),
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,8 @@
 #![warn(clippy::all, clippy::pedantic, clippy::cargo, clippy::nursery)]
 
 use colored::Colorize;
-use once_cell::sync::OnceCell;
+use once_cell::sync::Lazy;
+
 use regex::Regex;
 use solang_parser::pt::{
     ContractPart, FunctionAttribute, FunctionDefinition, SourceUnitPart, VariableAttribute,
@@ -11,6 +12,15 @@ use solang_parser::pt::{
 };
 use std::{error::Error, ffi::OsStr, fmt, fs, process};
 use walkdir::{DirEntry, WalkDir};
+
+// A regex matching test names such as `test_AddsTwoNumbers` or
+// `testFuzz_RevertIf_CallerIsUnauthorized`.
+static RE_VALID_TEST_NAME: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"test(Fork)?(Fuzz)?_(Revert(If_|When_){1})?\w+").unwrap());
+
+// A regex to ensure constant and immutable variables are in ALL_CAPS: https://regex101.com/r/Pv9mD8/1
+static RE_VALID_CONSTANT_NAME: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^_?[A-Z]+(?:_{0,1}[A-Z]+)*$").unwrap());
 
 // ========================
 // ======== Config ========
@@ -349,29 +359,9 @@ fn is_valid_test_name(name: &str) -> bool {
     if !name.starts_with("test") {
         return true // Not a test function, so return.
     }
-
-    let regex = regex!(r"test(Fork)?(Fuzz)?_(Revert(If_|When_){1})?\w+");
-    regex.is_match(name)
+    RE_VALID_TEST_NAME.is_match(name)
 }
 
 fn is_valid_constant_name(name: &str) -> bool {
-    // Make sure it's ALL_CAPS: https://regex101.com/r/Pv9mD8/1
-    let regex = regex!(r"^_?[A-Z]+(?:_{0,1}[A-Z]+)*$");
-    regex.is_match(name)
-}
-
-#[macro_use]
-mod macros {
-    #[macro_export]
-    /// This is a `regex!` macro which takes a string literal and returns an expression that
-    /// evaluates to a `&'static Regex`. This macro can be useful to avoid the "compile regex on
-    /// every loop iteration" problem. Read more:
-    ///   - <https://docs.rs/once_cell/latest/once_cell/#lazily-compiled-regex/>
-    ///   - <https://docs.rs/regex/latest/regex/#example-avoid-compiling-the-same-regex-in-a-loop/>
-    macro_rules! regex {
-        ($re:literal $(,)?) => {{
-            static RE: OnceCell<Regex> = OnceCell::new();
-            RE.get_or_init(|| Regex::new($re).unwrap())
-        }};
-    }
+    RE_VALID_CONSTANT_NAME.is_match(name)
 }


### PR DESCRIPTION
Replace hacky regex checks with solang, which is a solidity parser. One downside is that we currently lose line number info, but we can get it back in a future update. solang provides location data as start and end offsets in bytes, so we have to manually convert that to line number by mapping it to the input string.

Edit: foundry has the function we need to do that implemented [here](https://github.com/foundry-rs/foundry/blob/45b9dccdc8584fb5fbf55eb190a880d4e3b0753f/fmt/src/helpers.rs#L55-L70), so we can use that to report line numbers, h/t/ @rkrasiuk 