### PR TITLE
chore: fix panic

### DIFF
--- a/src/check/utils.rs
+++ b/src/check/utils.rs
@@ -195,21 +195,20 @@ impl VisibilitySummary for FunctionDefinition {
 }
 
 #[must_use]
-/// Converts the start offset of a `Loc` to `(line, col)`. Modified from <https://github.com/foundry-rs/foundry/blob/45b9dccdc8584fb5fbf55eb190a880d4e3b0753f/fmt/src/helpers.rs#L54-L70>
+/// Converts the start byte offset of a `Loc` to a 1-based line number.
+/// Uses `char_indices()` so that `start` (byte offset) is compared correctly for UTF-8 content.
 pub fn offset_to_line(content: &str, start: usize) -> usize {
-    debug_assert!(content.len() > start);
-
     let mut line_counter = 1; // First line is `1`.
-    for (offset, c) in content.chars().enumerate() {
+    for (byte_offset, c) in content.char_indices() {
         if c == '\n' {
             line_counter += 1;
         }
-        if offset > start {
+        if byte_offset > start {
             return line_counter;
         }
     }
-
-    unreachable!("content.len() > start")
+    // start is at or past end of content (e.g. empty file or parser edge case)
+    line_counter
 }
 
 // ===========================


### PR DESCRIPTION
## Problem

`offset_to_line` in `src/check/utils.rs` converts a finding's source location to a line number for display. It iterated `content.chars().enumerate()` — **character** indices — but compared them against `start`, which comes from solang `Loc`s and is a **byte** offset. The two only coincide for pure-ASCII files, which is why this went unnoticed.

For files containing multi-byte UTF-8 (emoji, non-Latin comments), there are two symptoms:

1. **Panic**: if a finding's byte offset exceeds the file's total character count (any finding near the end of a file with enough multi-byte content), the loop runs out of characters and hits `unreachable!("content.len() > start")`, crashing the entire `scopelint check` run:
   ```
   thread 'main' panicked at src/check/utils.rs:212:5:
   internal error: entered unreachable code: content.len() > start
   ```
   Repro: a file with a `// 🚀🚀🚀...` (300 emoji) comment followed by a naming violation.
2. **Wrong line numbers**: with less multi-byte content the loop merely returns late, attributing findings to later lines than the truth (e.g. a violation on line 6 reported on line 8).

## Fix

Iterate with `char_indices()` instead, which yields **byte** offsets, making the comparison byte-to-byte. The `debug_assert!`/`unreachable!` are replaced with a defensive fallback returning the last line when `start` is at or past EOF.

This was the only `chars().enumerate()` offset comparison in the codebase — other modules (e.g. `inline_config.rs`) already use `char_indices()` correctly.